### PR TITLE
Initialization of the variable bar_progress

### DIFF
--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -1819,6 +1819,7 @@ class Gantt {
             if (!($bar_progress && $bar_progress.finaldx)) return;
             bar.progress_changed();
             bar.set_action_completed();
+            $bar_progress = null;
         });
     }
 


### PR DESCRIPTION
Initialization of the variable bar_progress after the use of progress.
Case : change the progress of a bar. And after, move or change date of another bar. And the event "progress" will be called.